### PR TITLE
config: fix config name for old config

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -15,7 +15,7 @@ const (
 	// ConfigFileName is the name of config file
 	ConfigFileName = "config.json"
 	configFileDir  = ".balena"
-	oldConfigfile  = ".balena"
+	oldConfigfile  = ".balenacfg"
 )
 
 var (


### PR DESCRIPTION
This was accidentally changed to the directory during the big rename